### PR TITLE
allow for multiple lines for the same user or group

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,8 +1,12 @@
 sudoers:
   users:
-    johndoe: 'ALL=(ALL) ALL'
+    johndoe: 
+      - 'ALL=(ALL) ALL'
+      - 'ALL=(root) NOPASSWD: /etc/init.d/httpd'
   groups:
-    sudo: 'ALL=(ALL) NOPASSWD: ALL'
+    sudo: 
+      - 'ALL=(ALL) ALL'
+      - 'ALL=(nodejs) NOPASSWD: ALL'
   defaults:
     generic:
       - env_rset
@@ -39,6 +43,8 @@ sudoers:
   included_files:
     /etc/sudoers.d/extra-file:
       users:
-        foo: 'ALL=(ALL) ALL'
+        foo: 
+          - 'ALL=(ALL) ALL'
       groups:
-        bargroup: 'ALL=(ALL) NOPASSWD: ALL'
+        bargroup: 
+          - 'ALL=(ALL) NOPASSWD: ALL'

--- a/sudoers/files/sudoers
+++ b/sudoers/files/sudoers
@@ -82,13 +82,17 @@ Runas_Alias {{ name }} = {{ ",".join(runas) }}
 {%- endfor %}
 
 # User privilege specification
-{%- for user,spec in users.items() %}
+{%- for user,specs in users.items() %}
+  {%- for spec in specs %}
 {{ user }} {{ spec }}
+  {%- endfor %}
 {%- endfor %}
 
 # Group privilege specification
-{%- for group,spec in groups.items() %}
+{%- for group,specs in groups.items() %}
+  {%- for spec in specs %}
 %{{ group }} {{ spec }}
+  {%- endfor %}
 {%- endfor %}
 
 {% if includedir %}


### PR DESCRIPTION
Found cases where I needed the same username on multiple lines in sudoers and sudoers.d.  This change allows that functionality with minimal changes.  Updated pillar example to reflect the change.
