### PR TITLE
Fixed default permissions for Debian-based distributions.

### DIFF
--- a/sudoers/files/sudoers
+++ b/sudoers/files/sudoers
@@ -11,8 +11,8 @@
     {%- set host_list_defaults = defaults.get('host_list', {}) %}
     {%- set command_list_defaults = defaults.get('command_list', {}) %}
     {%- set runas_list_defaults = defaults.get('runas_list', {}) %}
-    {%- set users = sudoers.get('users', {'root': 'ALL=(ALL:ALL) ALL'}) %}
-    {%- set groups = sudoers.get('groups', {'sudo': 'ALL=(ALL:ALL) ALL'}) %}
+    {%- set users = sudoers.get('users', {'root': ['ALL=(ALL:ALL) ALL']}) %}
+    {%- set groups = sudoers.get('groups', {'sudo': ['ALL=(ALL:ALL) ALL']}) %}
   {%- else %}
     {%- set defaults = sudoers.get('defaults', {}) %}
     {%- set generic_defaults = defaults.get('generic', []) %}


### PR DESCRIPTION
The code around lines 84 and 91 expects 'specs' to be a list,
but the defaults provide a single string value. This causes
wrong behavior if sudoers:users or sudoers:groups are not
specified in pillar.
