### PR TITLE
included_files default changed to empty dict.

### DIFF
--- a/sudoers/included.sls
+++ b/sudoers/included.sls
@@ -4,7 +4,7 @@ include:
   - sudoers
 
 {% set sudoers = pillar.get('sudoers', {}) %}
-{% set included_files = sudoers.get('included_files', []) %}
+{% set included_files = sudoers.get('included_files', {}) %}
 {% for included_file,spec in included_files.items() -%}
 {{ included_file }}:
   file.managed:


### PR DESCRIPTION
included_files is a dictionary, yet the default is an emtpy list. This breaks on the next line where it is treated as a dict.
