### PR TITLE
Fixes escaped spaces in users/groups

### DIFF
--- a/sudoers/included.sls
+++ b/sudoers/included.sls
@@ -15,7 +15,7 @@ include:
     - source: salt://sudoers/files/sudoers
     - context:
         included: True
-        sudoers: {{ spec }}
+        sudoers: {{ spec|json }}
     - require:
       - file: {{ sudoers.get('config-path', '/etc') }}/sudoers
 {% endfor %}


### PR DESCRIPTION
This change allows for users/groups with spaces in them (must be escaped with a \ in the actual sudoers file) to actually work.  In the past if you had a group 'account management', your pillar would have an item such as this:

<pre><code>  groups:
    account\ management:
      - 'ALL=(ALL) ENCRYPT_SERVICES'
</code></pre>

as the name needs to get escaped.

What would actually get rendered would be double escaped as follows:

<pre><code>  %account\\ management ALL=(ALL) ENCRYPT_SERVICES
</code></pre>

Perhaps long-term it would be better to have the slashes for escaping generated by the template itself, but this quickly solves for the case right now.
