### PR TITLE
Fix overwriting dictionary with pillar data.

### DIFF
--- a/sudoers/included.sls
+++ b/sudoers/included.sls
@@ -3,7 +3,7 @@
 include:
   - sudoers
 
-{% set sudoers = pillar.get('sudoers', {}) %}
+{% do sudoers.update(pillar.get('sudoers', {})) %}
 {% set included_files = sudoers.get('included_files', {}) %}
 {% for included_file,spec in included_files.items() -%}
 {{ included_file }}:


### PR DESCRIPTION
The dictionary ``sudoers`` is set first from map, and then from pillar data. This results in losing map values. This updates, instead of overwrites the dictionary.