### PR TITLE
add sudoers file check with visudo

### DIFF
--- a/sudoers/included.sls
+++ b/sudoers/included.sls
@@ -13,6 +13,7 @@ include:
     - mode: 440
     - template: jinja
     - source: salt://sudoers/files/sudoers
+    - check_cmd: /usr/sbin/visudo -c -f
     - context:
         included: True
         sudoers: {{ spec|json }}

--- a/sudoers/init.sls
+++ b/sudoers/init.sls
@@ -11,6 +11,7 @@ sudo:
     - mode: 440
     - template: jinja
     - source: salt://sudoers/files/sudoers
+    - check_cmd: /usr/sbin/visudo -c -f
     - context:
         included: False
     - require:


### PR DESCRIPTION
I haven't found any (syntax, ..) check for the sudoers file before replacing with the new version (please correct me if i am wrong), so i implemented it as proposed here: https://blog.afoolishmanifesto.com/posts/checking-sudoers-with-visudo-in-saltstack/

I don't know if the path to visudo should be managed dynampcally in map.jinja and if a check for visudo (package) is necessary...