### PR TITLE
Use correct pathname of visudo on FreeBSD

### DIFF
--- a/sudoers/included.sls
+++ b/sudoers/included.sls
@@ -13,7 +13,7 @@ include:
     - mode: 440
     - template: jinja
     - source: salt://sudoers/files/sudoers
-    - check_cmd: /usr/sbin/visudo -c -f
+    - check_cmd: {{ sudoers.get('exec-prefix', '/usr/sbin') }}/visudo -c -f
     - context:
         included: True
         sudoers: {{ spec|json }}

--- a/sudoers/init.sls
+++ b/sudoers/init.sls
@@ -11,7 +11,7 @@ sudo:
     - mode: 440
     - template: jinja
     - source: salt://sudoers/files/sudoers
-    - check_cmd: /usr/sbin/visudo -c -f
+    - check_cmd: {{ sudoers.get('exec-prefix', '/usr/sbin') }}/visudo -c -f
     - context:
         included: False
     - require:

--- a/sudoers/map.jinja
+++ b/sudoers/map.jinja
@@ -11,5 +11,6 @@
     'Suse':    {'pkg': 'sudo'},
     'FreeBSD': {'pkg': 'sudo',
                 'config-path': '/usr/local/etc',
+                'exec-prefix': '/usr/local/sbin',
                 'group': 'wheel'},
 }, merge=salt['pillar.get']('sudoers:lookup')) %}


### PR DESCRIPTION
Without these changes the `file.managed` states in the `sudoers` and `sudoers.included` SLSes fail to run on FreeBSD with errors similar to the following:

```
          ID: /usr/local/etc/sudoers
    Function: file.managed
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/local/lib/python2.7/site-packages/salt/state.py", line 1624, in call
                  **cdata['kwargs'])
                File "/usr/local/lib/python2.7/site-packages/salt/loader.py", line 1491, in wrapper
                  return f(*args, **kwargs)
                File "/usr/local/lib/python2.7/site-packages/salt/states/file.py", line 1660, in managed
                  cret = mod_run_check_cmd(check_cmd, tmp_filename, **check_cmd_opts)
                File "/usr/local/lib/python2.7/site-packages/salt/states/file.py", line 4715, in mod_run_check_cmd
                  cret = __salt__['cmd.run_all'](_cmd, **check_cmd_opts)
                File "/usr/local/lib/python2.7/site-packages/salt/modules/cmdmod.py", line 1569, in run_all
                  use_vt=use_vt)
                File "/usr/local/lib/python2.7/site-packages/salt/modules/cmdmod.py", line 437, in _run
                  .format(cmd, kwargs, exc)
              CommandExecutionError: Unable to run command ['/usr/sbin/visudo', '-c', '-f', '/tmp/tmpiQWZ3K'] with the context {'with_communicate': True, 'shell': False, 'env': {'GROUP': 'wheel', 'REMOTEHOST': '10.63.1.24', 'HOSTTYPE': 'FreeBSD', 'LOGNAME': 'root', 'USER': 'root', 'HOME': '/root', 'PATH': '/sbin:/bin:/usr/sbin:/usr/bin:/usr/games:/usr/local/sbin:/usr/local/bin:/root/bin', 'DISPLAY': 'localhost:10.0', 'TERM': 'screen', 'SHELL': '/bin/csh', 'SHLVL': '1', 'BLOCKSIZE': 'K', 'EDITOR': 'vi', 'OSTYPE': 'FreeBSD', 'SUDO_USER': 'xenophon', 'USERNAME': 'root', 'VENDOR': 'amd', 'SUDO_UID': '5015', 'HOST': 'uxeprdbsdsalt01.irtnog.net', 'LC_ALL': 'C', 'SUDO_COMMAND': '/bin/csh', 'SUDO_GID': '10000', 'PWD': '/root', 'MAIL': '/var/mail/root', 'MACHTYPE': 'x86_64', 'PAGER': 'more'}, 'stdout': -1, 'close_fds': True, 'stdin': None, 'stderr': -1, 'cwd': '/root'}, reason: [Errno 2] No such file or directory
     Started: 15:08:11.084801
    Duration: 277.603 ms
     Changes:
```