### PR TITLE
added includedir as variable (mostly for FreeBSD)

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -45,6 +45,7 @@ sudoers:
       users:
         foo:
           - 'ALL=(ALL) ALL'
+    extra-file-2:
       groups:
         bargroup:
           - 'ALL=(ALL) NOPASSWD: ALL'

--- a/sudoers/included.sls
+++ b/sudoers/included.sls
@@ -4,10 +4,16 @@ include:
   - sudoers
 
 {% do sudoers.update(pillar.get('sudoers', {})) %}
+{% set includedir = sudoers.get('includedir', '/etc/sudoers.d') %}
 {% set included_files = sudoers.get('included_files', {}) %}
 {% for included_file,spec in included_files.items() -%}
-{{ included_file }}:
+sudoers include {{ included_file }}:
   file.managed:
+    {% if '/' in included_file %}
+    - name: {{ included_file }}
+    {% else %}
+    - name: {{ includedir }}/{{ included_file }}
+    {% endif %}
     - user: root
     - group: {{ sudoers.get('group', 'root') }}
     - mode: 440

--- a/sudoers/map.jinja
+++ b/sudoers/map.jinja
@@ -11,6 +11,7 @@
     'Suse':    {'pkg': 'sudo'},
     'FreeBSD': {'pkg': 'sudo',
                 'configpath': '/usr/local/etc',
+                'includedir': '/usr/local/etc/sudoers.d',
                 'execprefix': '/usr/local/sbin',
                 'group': 'wheel'},
 }, merge=salt['pillar.get']('sudoers:lookup')) %}


### PR DESCRIPTION
added includedir as variable (mostly for FreeBSD)
include files can now be specified with the filename only (that is the sudoers.d path will be added automatically).