### PR TITLE
Need to be able to handle netgroups

### DIFF
--- a/sudoers/files/sudoers
+++ b/sudoers/files/sudoers
@@ -91,7 +91,7 @@ Runas_Alias {{ name }} = {{ ",".join(runas) }}
 # Group privilege specification
 {%- for group,specs in groups.items() %}
   {%- for spec in specs %}
-%{{ group }} {{ spec }}
+{{ group }} {{ spec }}
   {%- endfor %}
 {%- endfor %}
 


### PR DESCRIPTION
This makes it incompatible with netgroups. netgroups are defined with a "+" symbol in front.  For example +mynetgroup.