### PR TITLE
Add support for netgroups

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -7,6 +7,9 @@ sudoers:
     sudo:
       - 'ALL=(ALL) ALL'
       - 'ALL=(nodejs) NOPASSWD: ALL'
+  netgroups:
+    sysadmins:
+      - 'ALL=(ALL) ALL'
   defaults:
     generic:
       - env_reset
@@ -49,3 +52,7 @@ sudoers:
       groups:
         bargroup:
           - 'ALL=(ALL) NOPASSWD: ALL'
+    extra-file-3:
+      netgroups:
+        other_netgroup:
+          - 'ALL=(ALL) ALL'

--- a/sudoers/files/sudoers
+++ b/sudoers/files/sudoers
@@ -13,6 +13,7 @@
     {%- set runas_list_defaults = defaults.get('runas_list', {}) %}
     {%- set users = sudoers.get('users', {'root': ['ALL=(ALL:ALL) ALL']}) %}
     {%- set groups = sudoers.get('groups', {'sudo': ['ALL=(ALL:ALL) ALL']}) %}
+    {%- set netgroups = sudoers.get('netgroups', {}) %}
   {%- else %}
     {%- set defaults = sudoers.get('defaults', {}) %}
     {%- set generic_defaults = defaults.get('generic', []) %}
@@ -22,6 +23,7 @@
     {%- set runas_list_defaults = defaults.get('runas_list', {}) %}
     {%- set users = sudoers.get('users', {}) %}
     {%- set groups = sudoers.get('groups', {}) %}
+    {%- set netgroups = sudoers.get('netgroups', {}) %}
   {%- endif %}
   {%- set includedir = sudoers.get('includedir', '/etc/sudoers.d') -%}
 {%- else %}
@@ -33,6 +35,7 @@
   {%- set runas_list_defaults = defaults.get('runas_list', {}) %}
   {%- set users = sudoers.get('users', {}) %}
   {%- set groups = sudoers.get('groups', {}) %}
+  {%- set netgroups = sudoers.get('netgroups', {}) %}
   {%- set includedir = sudoers.get('includedir', None) %}
 {%- endif %}
 {%- set aliases = sudoers.get('aliases', {}) %}
@@ -92,6 +95,13 @@ Runas_Alias {{ name }} = {{ ",".join(runas) }}
 {%- for group,specs in groups.items() %}
   {%- for spec in specs %}
 %{{ group }} {{ spec }}
+  {%- endfor %}
+{%- endfor %}
+
+# Netgroup privilege specification
+{%- for netgroup,specs in netgroups.items() %}
+  {%- for spec in specs %}
++{{ netgroup }} {{ spec }}
   {%- endfor %}
 {%- endfor %}
 


### PR DESCRIPTION
Hello!

I've created this pull request to add support for netgroups to sudoers-formula. Netgroups are similar to regular groups but the entries in the sudoers file are prefixed with a plus sign (`+`) instead of a percent sign. You can find out more information about netgroups in the [sudoers man page](https://www.sudo.ws/man/1.8.23/sudoers.man.html) . 

Please let me know what you think!