### PR TITLE
Make management of the main sudoers config optional

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,6 @@
 sudoers:
+  # By default the main sudoers file is managed by this formula (False to skip)
+  manage_main_config: True
   users:
     johndoe:
       - 'ALL=(ALL) ALL'

--- a/sudoers/included.sls
+++ b/sudoers/included.sls
@@ -23,6 +23,8 @@ sudoers include {{ included_file }}:
     - context:
         included: True
         sudoers: {{ spec|json }}
+    {% if salt['pillar.get']('sudoers:manage_main_config', True) %}
     - require:
       - file: {{ sudoers.get('configpath', '/etc') }}/sudoers
+    {% endif %}
 {% endfor %}

--- a/sudoers/init.sls
+++ b/sudoers/init.sls
@@ -4,6 +4,8 @@ sudo:
   pkg.installed:
     - name: {{ sudoers.pkg }}
 
+{% if salt['pillar.get']('sudoers:manage_main_config', True) %}
+
 {{ sudoers.get('configpath', '/etc') }}/sudoers:
   file.managed:
     - user: root
@@ -16,3 +18,12 @@ sudo:
         included: False
     - require:
       - pkg: sudo
+
+{% else %}
+
+{{ sudoers.get('configpath', '/etc') }}/sudoers:
+  test.show_notification:
+    - name: Skipping management of main sudoers file
+    - text: Pillar manage_main_config is False
+
+{% endif %}


### PR DESCRIPTION
It should be possible to not overwrite the main sudoers configuration
file and only provide files to be included. This introduces a new Pillar
variable to achieve that. If it's not set we default to the old
behaviour of managing that file.