### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -45,16 +45,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example test/salt/pillar/kitchen.sls test/salt/pillar/default.sls
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/pillar.example
+++ b/pillar.example
@@ -3,7 +3,7 @@
 ---
 sudoers:
   # By default the main sudoers file is managed by this formula (False to skip)
-  manage_main_config: True
+  manage_main_config: true
   users:
     johndoe:
       - 'ALL=(ALL) ALL'

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: sudoers formula
 maintainer: SaltStack Formulas

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -1,6 +1,9 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 sudoers:
   # By default the main sudoers file is managed by this formula (False to skip)
-  manage_main_config: True
+  manage_main_config: true
   users:
     johndoe:
       - 'ALL=(ALL) ALL'

--- a/test/salt/pillar/kitchen.sls
+++ b/test/salt/pillar/kitchen.sls
@@ -1,7 +1,9 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 # Pillar needed to run Inspec inside Docker image using sudo to authenticate
 # Must be added to pillar of all test suites
 sudoers:
   users:
     kitchen:
       - 'ALL=(root) NOPASSWD: ALL'
-


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
sudoers-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
pillar.example
  6:23      warning  truthy value should be one of [false, true]  (truthy)

test/salt/pillar/kitchen.sls
  3:1       warning  missing document start "---"  (document-start)
  7:1       error    too many blank lines (1 > 0)  (empty-lines)

test/salt/pillar/default.sls
  1:1       warning  missing document start "---"  (document-start)
  3:23      warning  truthy value should be one of [false, true]  (truthy)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.